### PR TITLE
ignore lazy load store model

### DIFF
--- a/src/main/java/com/ss/dto/response/OrderResponse.java
+++ b/src/main/java/com/ss/dto/response/OrderResponse.java
@@ -1,5 +1,6 @@
 package com.ss.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.ss.enums.OrderStatus;
 import com.ss.model.*;
 import lombok.Data;
@@ -44,6 +45,7 @@ public class OrderResponse {
 
         private String code;
 
+        @JsonIgnoreProperties({"hibernateLazyInitializer"})
         private StoreModel store;
 
         public ProductRes product;


### PR DESCRIPTION
**### Error:**
No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: com.ss.dto.response.ServiceResponse["data"]->java.util.ArrayList[0]->com.ss.dto.response.OrderToolResponse["order"]->com.ss.dto.response.OrderResponse["items"]->java.util.ArrayList[0]->com.ss.dto.response.OrderResponse$OrderItemRes["store"]->com.ss.model.StoreModel$HibernateProxy$X0xSSrIa["hibernateLazyInitializer"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77) ~[jackson-databind-2.13.4.jar:2.13.4]
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1300) ~[jackson-databind-2.13.4.jar:2.13.4]
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:400) ~[jackson-databind-2.13.4.jar:2.13.4]